### PR TITLE
[Critstun patch part 1]

### DIFF
--- a/src/Drawings/FightManager.js
+++ b/src/Drawings/FightManager.js
@@ -53,19 +53,25 @@ class FightManager {
         let ind = fight.summaryIndex;
         let summary = fight.summary;
         if (ind < summary.rounds.length) {
-
+            
+            let hitText = "";
+            if (summary.rounds[ind].critical === true && summary.rounds[ind].stun === true) {
+                hitText = " (" + Translator.getString(lang, "fight_general", "critstun_hit") + "!) ";
+            } else if (summary.rounds[ind].critical === true) {
+                hitText = " (" + Translator.getString(lang, "fight_general", "critical_hit") + "!) ";
+            } else if (summary.rounds[ind].stun === true) {
+                hitText = " (" + Translator.getString(lang, "fight_general", "stun_hit") + "!) ";
+            }
+            
             if (summary.rounds[ind].roundType == "Character") {
                 fight = this.swapArrayIndexes("<:user:403148210295537664> " + Translator.getString(lang, "fight_pve", "onfight_user_attack", [summary.rounds[ind].attackerName, summary.rounds[ind].defenderName, summary.rounds[ind].damage]) +
-                    (summary.rounds[ind].critical === true ? " (" + Translator.getString(lang, "fight_general", "critical_hit") + "!) " : "") +
-                    (summary.rounds[ind].stun === true ? " (" + Translator.getString(lang, "fight_general", "stun_hit") + "!) " : "") +
+                    hitText +
                     "\n\n", fight);
             } else if (summary.rounds[ind].roundType == "Monster") {
                 fight = this.swapArrayIndexes("<:monstre:403149357387350016> " + Translator.getString(lang, "fight_pve", "onfight_monster_attack", [summary.rounds[ind].attackerName, summary.rounds[ind].defenderName, summary.rounds[ind].damage]) +
-                    (summary.rounds[ind].critical === true ? " (" + Translator.getString(lang, "fight_general", "critical_hit") + "!) " : "") +
-                    (summary.rounds[ind].stun === true ? " (" + Translator.getString(lang, "fight_general", "stun_hit") + "!) " : "") +
+                    hitText +
                     "\n\n", fight);
             }
-
 
 
             message.edit(this.embedPvE(fight.text[0] + fight.text[1] + fight.text[2], fight, null, lang))


### PR DESCRIPTION
Instead of displaying "(Critical hit!) (Stun hit!)" if both, it should now display "(Critical stun hit!)"
This change should be safe to pull with or without pulling the others in (backwards compatibility)