### PR TITLE
Leaderboard drawing improvements

### DIFF
--- a/src/Drawings/Leaderboard/LeaderboardCraftLevel.js
+++ b/src/Drawings/Leaderboard/LeaderboardCraftLevel.js
@@ -52,7 +52,7 @@ class LeaderboardCraftLevel extends Leaderboard {
 
             rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("hammer") + actualLevelString + Emojis.getString("exp") + actualExpString + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + "\n";
         }
-        return "**" + Translator.getString(lang, "leaderboards", "craftlevel", [this.sumOfAll.totalLevels, this.sumOfAll.totalExp]) + " (" + this.maximumRank + ")" + "**\n\n" + rankings;
+        return "**" + Translator.getString(lang, "leaderboards", "craftlevel", [this.sumOfAll.totalLevels, this.sumOfAll.totalExp]) + " (" + Translator.getFormater(this.lang).format(this.maximumRank) + ")" + "**\n\n" + rankings;
     }
 }
 

--- a/src/Drawings/Leaderboard/LeaderboardCraftLevel.js
+++ b/src/Drawings/Leaderboard/LeaderboardCraftLevel.js
@@ -50,7 +50,7 @@ class LeaderboardCraftLevel extends Leaderboard {
 
 
 
-            rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("hammer") + actualLevelString + Emojis.getString("exp") + actualExpString + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + "\n";
+            rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("hammer") + actualLevelString + Emojis.getString("exp") + actualExpString + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + " (" + user.actualLevel + ")" + "\n";
         }
         return "**" + Translator.getString(lang, "leaderboards", "craftlevel", [this.sumOfAll.totalLevels, this.sumOfAll.totalExp]) + " (" + Translator.getFormater(this.lang).format(this.maximumRank) + ")" + "**\n\n" + rankings;
     }

--- a/src/Drawings/Leaderboard/LeaderboardGold.js
+++ b/src/Drawings/Leaderboard/LeaderboardGold.js
@@ -33,7 +33,7 @@ class LeaderboardGold extends Leaderboard {
 
             rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("money_bag") + userMoneyStringBefore + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + "\n";
         }
-        return "**" + Translator.getString(lang, "leaderboards", "gold", [this.sumOfAll.totalGold]) + " (" + this.maximumRank + ")" + "**\n\n" + rankings;
+        return "**" + Translator.getString(lang, "leaderboards", "gold", [this.sumOfAll.totalGold]) + " (" + Translator.getFormater(this.lang).format(this.maximumRank) + ")" + "**\n\n" + rankings;
     }
 }
 

--- a/src/Drawings/Leaderboard/LeaderboardGold.js
+++ b/src/Drawings/Leaderboard/LeaderboardGold.js
@@ -31,7 +31,7 @@ class LeaderboardGold extends Leaderboard {
             let userMoneyStringBefore = "`" + "•".repeat(maximumGoldLength - goldString.length) + goldString + "`";
 
 
-            rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("money_bag") + userMoneyStringBefore + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + "\n";
+            rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("money_bag") + userMoneyStringBefore + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + " (" + user.actualLevel + ")" + "\n";
         }
         return "**" + Translator.getString(lang, "leaderboards", "gold", [this.sumOfAll.totalGold]) + " (" + Translator.getFormater(this.lang).format(this.maximumRank) + ")" + "**\n\n" + rankings;
     }

--- a/src/Drawings/Leaderboard/LeaderboardLevel.js
+++ b/src/Drawings/Leaderboard/LeaderboardLevel.js
@@ -52,7 +52,7 @@ class LeaderboardLevel extends Leaderboard {
 
             rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("levelup") + actualLevelString + Emojis.getString("exp") + actualExpString + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + "\n";
         }
-        return "**" + Translator.getString(lang, "leaderboards", "level", [this.sumOfAll.totalLevels, this.sumOfAll.totalExp]) + " (" + this.maximumRank + ")" + "**\n\n" + rankings;
+        return "**" + Translator.getString(lang, "leaderboards", "level", [this.sumOfAll.totalLevels, this.sumOfAll.totalExp]) + " (" + Translator.getFormater(this.lang).format(this.maximumRank) + ")" + "**\n\n" + rankings;
     }
 }
 

--- a/src/Drawings/Leaderboard/LeaderboardPvP.js
+++ b/src/Drawings/Leaderboard/LeaderboardPvP.js
@@ -31,7 +31,7 @@ class LeaderboardPvP extends Leaderboard {
 
             rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("honor") + honorString + Emojis.getString("idFRPG") + "`" + user.idCharacter + "` - " + user.userName + " (" + user.actualLevel + ")" + "\n";
         }
-        return "**" + Translator.getString(lang, "leaderboards", "arena", [this.sumOfAll.totalHonor]) + " (" + this.maximumRank + ")" + "**\n\n" + rankings;
+        return "**" + Translator.getString(lang, "leaderboards", "arena", [this.sumOfAll.totalHonor]) + " (" + Translator.getFormater(this.lang).format(this.maximumRank) + ")" + "**\n\n" + rankings;
     }
 }
 

--- a/src/Drawings/Leaderboard/LeaderboardWBAttacks.js
+++ b/src/Drawings/Leaderboard/LeaderboardWBAttacks.js
@@ -32,7 +32,7 @@ class LeaderboardWBAttacks extends Leaderboard {
                 let attackString = Translator.getFormater(this.lang).format(user.attackCount);
                 let userAttackString = "`" + "•".repeat(maximumAttacksLength - attackString.length) + attackString + "`";
 
-                rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("sword") + userAttackString + " - " + user.userName + "(" + user.actualLevel + ")" + "\n";
+                rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("sword") + userAttackString + " - " + user.userName + " (" + user.actualLevel + ")" + "\n";
             }
 
 

--- a/src/Drawings/Leaderboard/LeaderboardWBDamage.js
+++ b/src/Drawings/Leaderboard/LeaderboardWBDamage.js
@@ -31,7 +31,7 @@ class LeaderboardWBDamage extends Leaderboard {
                 let damageString = Translator.getFormater(this.lang).format(user.damage);
                 let userDamageString = "`" + "•".repeat(maximumDamageLenght - damageString.length) + Translator.getFormater(this.lang).format(user.damage) + "`";
 
-                rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("sword") + userDamageString + " - " + user.userName + "(" + user.actualLevel + ")" + "\n";
+                rankings += Emojis.getString("win") + "`" + (offsetStr) + ". `" + Emojis.getString("sword") + userDamageString + " - " + user.userName + " (" + user.actualLevel + ")" + "\n";
             }
             return "**" + Translator.getString(lang, "leaderboards", "wb_damage") + " (" + this.maximumRank + ")" + "**\n\n" + rankings;
         }


### PR DESCRIPTION
UNTESTED but should work first try (all changes are basic)
I can't test cause you messed up the leaderboards database on my bot version and I didn't update yet

Changelist: made all* instances of this.maxRank be formatted by the formatter (wbleaderboard excluded cause it's not needed), added missing spaces before player level (it was inconsistent), Gold and Craft leaderboard now will show the player level too next to the player name